### PR TITLE
Update Gemfile.lock to be cross platform

### DIFF
--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -47,6 +47,7 @@ GEM
     faraday-net_http (3.4.2)
       net-http (~> 0.5)
     ffi (1.17.3)
+    ffi (1.17.3-arm64-darwin)
     ffi (1.17.3-x64-mingw-ucrt)
     ffi (1.17.3-x86_64-darwin)
     ffi (1.17.3-x86_64-linux-gnu)
@@ -244,6 +245,8 @@ GEM
     nokogiri (1.19.0)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
+    nokogiri (1.19.0-arm64-darwin)
+      racc (~> 1.4)
     nokogiri (1.19.0-x64-mingw-ucrt)
       racc (~> 1.4)
     nokogiri (1.19.0-x86_64-darwin)
@@ -286,6 +289,7 @@ GEM
     webrick (1.9.2)
 
 PLATFORMS
+  arm64-darwin
   ruby
   x64-mingw-ucrt
   x86_64-darwin


### PR DESCRIPTION
Miscellaneous change to allow for cross-platform building of the jekyll site.