### PR TITLE
Show clear error when apt note exceeds max length and update UG to reflect

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -259,6 +259,7 @@ Format: `apt PATIENT_NUMBER d/DATETIME dur/DURATION [note/NOTE]`
 * The date and time must be in the format `dd-MM-yyyy HH:mm` e.g., `12-03-2026 14:00` refers to 12th March 2026, 14:00.
 * The duration **must be a positive integer** in **minutes**.
 * The note is optional.
+* If provided, `NOTE` must be at most **500 characters**.
 
 <div markdown="span" class="alert alert-warning">:exclamation: **Caution:**
 If the patient already has an existing appointment, it will be 

--- a/src/main/java/doctorwho/logic/parser/AddAppointmentCommandParser.java
+++ b/src/main/java/doctorwho/logic/parser/AddAppointmentCommandParser.java
@@ -18,6 +18,9 @@ import doctorwho.model.patient.Appointment;
  */
 public class AddAppointmentCommandParser implements Parser<AddAppointmentCommand> {
 
+    public static final String MESSAGE_NOTE_TOO_LONG =
+            String.format("Appointment note must not exceed %d characters.", Appointment.MAX_LENGTH);
+
     /**
      * Parses the given {@code String} of arguments in the context of the AddAppointmentCommand
      * and returns an AddAppointmentCommand object for execution.
@@ -53,6 +56,10 @@ public class AddAppointmentCommandParser implements Parser<AddAppointmentCommand
         String startTimeStr = argMultimap.getValue(PREFIX_APPOINTMENT_STARTTIME).get();
         int duration = ParserUtil.parsePositiveInteger(argMultimap.getValue(PREFIX_APPOINTMENT_DURATION).get());
         String note = argMultimap.getValue(PREFIX_APPOINTMENT_NOTE).orElse("");
+
+        if (note.length() > Appointment.MAX_LENGTH) {
+            throw new ParseException(MESSAGE_NOTE_TOO_LONG);
+        }
 
         Appointment appointment;
 

--- a/src/test/java/doctorwho/logic/parser/AddAppointmentCommandParserTest.java
+++ b/src/test/java/doctorwho/logic/parser/AddAppointmentCommandParserTest.java
@@ -152,4 +152,16 @@ public class AddAppointmentCommandParserTest {
                 Messages.getErrorMessageForDuplicatePrefixes(
                         PREFIX_APPOINTMENT_NOTE));
     }
+
+    @Test
+    public void parse_noteTooLong_failure() {
+        String overlongNote = " note/" + "a".repeat(Appointment.MAX_LENGTH + 1);
+        String userInput = INDEX_FIRST_PATIENT.getOneBased()
+                        + APPOINTMENT_STARTTIME_DESC_VALID
+                        + APPOINTMENT_DURATION_DESC_VALID
+                        + overlongNote;
+
+        assertParseFailure(parser, userInput, AddAppointmentCommandParser.MESSAGE_NOTE_TOO_LONG);
+    }
+
 }


### PR DESCRIPTION
Fixes #181 

Adds warning inside of UG as well as when the note limit of 500 characters is exceeded.
Adds tests for coverage of this new warning as well.