### PR TITLE
Fix detail panel overflow; remove name wraparound in Cardlist

### DIFF
--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -15,7 +15,7 @@
 
 <?import javafx.scene.control.Label?>
 <fx:root type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1"
-         title="DoctorWho" minWidth="450" minHeight="600" onCloseRequest="#handleExit">
+         title="DoctorWho" minWidth="900" minHeight="700" onCloseRequest="#handleExit">
   <icons>
     <Image url="@/images/address_book_32.png" />
   </icons>
@@ -62,7 +62,7 @@
           </padding>
         </StackPane>
 
-        <SplitPane dividerPositions="0.3" VBox.vgrow="ALWAYS" styleClass="pane-with-border">
+        <SplitPane fx:id="mainSplitPane" dividerPositions="0.3" VBox.vgrow="ALWAYS" styleClass="pane-with-border">
           <items>
             <VBox fx:id="personList" minWidth="250" prefWidth="300" styleClass="pane-with-border">
               <padding>

--- a/src/main/resources/view/PatientDetailPanel.fxml
+++ b/src/main/resources/view/PatientDetailPanel.fxml
@@ -9,13 +9,13 @@
 <?import javafx.scene.layout.HBox?>
 <?import javafx.scene.layout.VBox?>
 
-<VBox xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1" fx:id="detailPane" styleClass="patient-detail-panel" prefWidth="600">
+<VBox xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1" fx:id="detailPane" styleClass="patient-detail-panel" prefWidth="600" minHeight="0">
     <padding>
         <Insets top="20" right="20" bottom="20" left="20" />
     </padding>
 
     <VBox spacing="2" VBox.vgrow="NEVER" styleClass="detail-header-section">
-        <Label fx:id="name" styleClass="cell_big_label" text="\$patientName" minWidth="0" minHeight="-Infinity" wrapText="true" maxWidth="1.7976931348623157E308"/>
+        <Label fx:id="name" styleClass="cell_big_label" text="\$patientName" minWidth="0" wrapText="true" minHeight="-Infinity" maxWidth="1.7976931348623157E308"/>
         <HBox spacing="10" alignment="CENTER_LEFT">
             <Label fx:id="sex" styleClass="cell_small_label" text="\$sex" />
             <Label styleClass="cell_small_label" text="/" />
@@ -23,7 +23,7 @@
         </HBox>
     </VBox>
 
-    <ScrollPane fitToWidth="true" VBox.vgrow="ALWAYS" styleClass="detail-scroll-pane">
+    <ScrollPane fitToWidth="true" fitToHeight="true" minHeight="0" VBox.vgrow="ALWAYS" styleClass="detail-scroll-pane">
         <content>
             <VBox spacing="15">
                 <padding>

--- a/src/main/resources/view/PatientListCard.fxml
+++ b/src/main/resources/view/PatientListCard.fxml
@@ -26,7 +26,7 @@
             <Region fx:constant="USE_PREF_SIZE"/>
           </minWidth>
         </Label>
-        <Label fx:id="name" text="\$first" styleClass="cell_big_label" wrapText="true" HBox.hgrow="ALWAYS" maxWidth="1.7976931348623157E308"/>
+        <Label fx:id="name" text="\$first" styleClass="cell_big_label" HBox.hgrow="ALWAYS" maxWidth="1.7976931348623157E308"/>
       </HBox>
 
       <FlowPane fx:id="tags" hgap="5" vgap="5">


### PR DESCRIPTION
- Force detail panel maximum height
- Remove name wraparound in Card list display
- Add name wraparound in Detail Panel display

Fixes #246 