### PR TITLE
Add invalid prefix error

### DIFF
--- a/src/main/java/doctorwho/logic/parser/ArgumentTokenizer.java
+++ b/src/main/java/doctorwho/logic/parser/ArgumentTokenizer.java
@@ -3,7 +3,12 @@ package doctorwho.logic.parser;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+
+import doctorwho.logic.parser.exceptions.ParseException;
 
 /**
  * Tokenizes arguments string of the form: {@code preamble <prefix>value <prefix>value ...}<br>
@@ -14,6 +19,7 @@ import java.util.stream.Collectors;
  * in the above example.<br>
  */
 public class ArgumentTokenizer {
+    private static final Pattern PREFIX_PATTERN = Pattern.compile("(?<=\\s|^)(" + CliSyntax.PREFIX_REGEX + ")");
 
     /**
      * Tokenizes an arguments string and returns an {@code ArgumentMultimap} object that maps prefixes to their
@@ -23,9 +29,23 @@ public class ArgumentTokenizer {
      * @param prefixes   Prefixes to tokenize the arguments string with
      * @return ArgumentMultimap object that maps prefixes to their arguments
      */
-    public static ArgumentMultimap tokenize(String argsString, Prefix... prefixes) {
+    public static ArgumentMultimap tokenize(String argsString, Prefix... prefixes) throws ParseException {
+        validateNoUnknownPrefixes(argsString, prefixes);
         List<PrefixPosition> positions = findAllPrefixPositions(argsString, prefixes);
         return extractArguments(argsString, positions);
+    }
+
+    private static void validateNoUnknownPrefixes(String argsString, Prefix... prefixes) throws ParseException {
+        Set<String> allowed = Arrays.stream(prefixes)
+                .map(Prefix::getPrefix)
+                .collect(Collectors.toSet());
+        Matcher matcher = PREFIX_PATTERN.matcher(argsString);
+        while (matcher.find()) {
+            String found = matcher.group(1);
+            if (!allowed.contains(found)) {
+                throw new ParseException("Unknown prefix: " + found);
+            }
+        }
     }
 
     /**

--- a/src/main/java/doctorwho/logic/parser/CliSyntax.java
+++ b/src/main/java/doctorwho/logic/parser/CliSyntax.java
@@ -4,7 +4,7 @@ package doctorwho.logic.parser;
  * Contains Command Line Interface (CLI) syntax definitions common to multiple commands
  */
 public class CliSyntax {
-
+    public static final String PREFIX_REGEX = "[a-zA-Z]+/";
     /* Prefix definitions */
     // used by add, edit
     public static final Prefix PREFIX_NAME = new Prefix("n/");

--- a/src/main/java/doctorwho/logic/parser/DeleteAppointmentCommandParser.java
+++ b/src/main/java/doctorwho/logic/parser/DeleteAppointmentCommandParser.java
@@ -18,6 +18,7 @@ public class DeleteAppointmentCommandParser implements Parser<DeleteAppointmentC
      * @throws ParseException if the user input does not conform the expected format
      */
     public DeleteAppointmentCommand parse(String args) throws ParseException {
+        ArgumentTokenizer.tokenize(args);
         try {
             Index index = ParserUtil.parseIndex(args);
             return new DeleteAppointmentCommand(index);

--- a/src/main/java/doctorwho/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/doctorwho/logic/parser/DeleteCommandParser.java
@@ -18,6 +18,7 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
      * @throws ParseException if the user input does not conform the expected format
      */
     public DeleteCommand parse(String args) throws ParseException {
+        ArgumentTokenizer.tokenize(args);
         try {
             Index index = ParserUtil.parseIndex(args);
             return new DeleteCommand(index);

--- a/src/main/java/doctorwho/logic/parser/FindCommandParser.java
+++ b/src/main/java/doctorwho/logic/parser/FindCommandParser.java
@@ -20,6 +20,7 @@ public class FindCommandParser implements Parser<FindCommand> {
      * @throws ParseException if the user input does not conform the expected format
      */
     public FindCommand parse(String args) throws ParseException {
+        ArgumentTokenizer.tokenize(args);
         String trimmedArgs = args.trim();
         if (trimmedArgs.isEmpty()) {
             throw new ParseException(

--- a/src/test/java/doctorwho/logic/parser/ArgumentTokenizerTest.java
+++ b/src/test/java/doctorwho/logic/parser/ArgumentTokenizerTest.java
@@ -7,6 +7,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 
+import doctorwho.logic.parser.exceptions.ParseException;
+
 public class ArgumentTokenizerTest {
 
     private final Prefix unknownPrefix = new Prefix("--u");
@@ -15,7 +17,7 @@ public class ArgumentTokenizerTest {
     private final Prefix hatQ = new Prefix("^Q");
 
     @Test
-    public void tokenize_emptyArgsString_noValues() {
+    public void tokenize_emptyArgsString_noValues() throws ParseException {
         String argsString = "  ";
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(argsString, pSlash);
 
@@ -54,7 +56,7 @@ public class ArgumentTokenizerTest {
     }
 
     @Test
-    public void tokenize_noPrefixes_allTakenAsPreamble() {
+    public void tokenize_noPrefixes_allTakenAsPreamble() throws ParseException {
         String argsString = "  some random string /t tag with leading and trailing spaces ";
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(argsString);
 
@@ -64,7 +66,7 @@ public class ArgumentTokenizerTest {
     }
 
     @Test
-    public void tokenize_oneArgument() {
+    public void tokenize_oneArgument() throws ParseException {
         // Preamble present
         String argsString = "  Some preamble string p/ Argument value ";
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(argsString, pSlash);
@@ -80,7 +82,7 @@ public class ArgumentTokenizerTest {
     }
 
     @Test
-    public void tokenize_multipleArguments() {
+    public void tokenize_multipleArguments() throws ParseException {
         // Only two arguments are present
         String argsString = "SomePreambleString -t dashT-Value p/pSlash value";
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(argsString, pSlash, dashT, hatQ);
@@ -116,7 +118,7 @@ public class ArgumentTokenizerTest {
     }
 
     @Test
-    public void tokenize_multipleArgumentsWithRepeats() {
+    public void tokenize_multipleArgumentsWithRepeats() throws ParseException {
         // Two arguments repeated, some have empty values
         String argsString = "SomePreambleString -t dashT-Value ^Q ^Q -t another dashT value p/ pSlash value -t";
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(argsString, pSlash, dashT, hatQ);
@@ -127,11 +129,11 @@ public class ArgumentTokenizerTest {
     }
 
     @Test
-    public void tokenize_multipleArgumentsJoined() {
-        String argsString = "SomePreambleStringp/ pSlash joined-tjoined -t not joined^Qjoined";
+    public void tokenize_multipleArgumentsJoined() throws ParseException {
+        String argsString = "SomePreambleString p/ pSlash joined-tjoined -t not joined^Qjoined";
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(argsString, pSlash, dashT, hatQ);
-        assertPreamblePresent(argMultimap, "SomePreambleStringp/ pSlash joined-tjoined");
-        assertArgumentAbsent(argMultimap, pSlash);
+        assertPreamblePresent(argMultimap, "SomePreambleString");
+        assertArgumentPresent(argMultimap, pSlash, "pSlash joined-tjoined");
         assertArgumentPresent(argMultimap, dashT, "not joined^Qjoined");
         assertArgumentAbsent(argMultimap, hatQ);
     }

--- a/src/test/java/doctorwho/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/doctorwho/logic/parser/EditCommandParserTest.java
@@ -85,9 +85,13 @@ public class EditCommandParserTest {
 
         // invalid arguments being parsed as preamble
         assertParseFailure(parser, "1 some random string", MESSAGE_INVALID_FORMAT);
+    }
 
+    @Test
+    void parse_invalidPrexi_failure() {
         // invalid prefix being parsed as preamble
-        assertParseFailure(parser, "1 i/ string", MESSAGE_INVALID_FORMAT);
+        String prefix = "i/";
+        assertParseFailure(parser, "1 " + prefix + " string", "Unknown prefix: " + prefix);
     }
 
     @Test
@@ -124,9 +128,9 @@ public class EditCommandParserTest {
                 + EMAIL_DESC_AMY + ADDRESS_DESC_AMY + NAME_DESC_AMY + ALLERGY_DESC_ASPIRIN + CONDITION_DESC_DIABETES;
 
         EditPatientDescriptor descriptor = new EditPatientDescriptorBuilder().withName(VALID_NAME_AMY)
-            .withPhone(VALID_PHONE_BOB).withEmail(VALID_EMAIL_AMY).withAddress(VALID_ADDRESS_AMY)
-            .withAllergies(VALID_ALLERGY_IBUPROFEN, VALID_ALLERGY_ASPIRIN)
-            .withConditions(VALID_CONDITION_DIABETES).build();
+                .withPhone(VALID_PHONE_BOB).withEmail(VALID_EMAIL_AMY).withAddress(VALID_ADDRESS_AMY)
+                .withAllergies(VALID_ALLERGY_IBUPROFEN, VALID_ALLERGY_ASPIRIN)
+                .withConditions(VALID_CONDITION_DIABETES).build();
         EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
 
         assertParseSuccess(parser, userInput, expectedCommand);
@@ -138,7 +142,7 @@ public class EditCommandParserTest {
         String userInput = targetIndex.getOneBased() + PHONE_DESC_BOB + EMAIL_DESC_AMY;
 
         EditPatientDescriptor descriptor = new EditPatientDescriptorBuilder().withPhone(VALID_PHONE_BOB)
-            .withEmail(VALID_EMAIL_AMY).build();
+                .withEmail(VALID_EMAIL_AMY).build();
         EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
 
         assertParseSuccess(parser, userInput, expectedCommand);


### PR DESCRIPTION
Fixes #197 

The following now return an error for the invalid `c/` prefix:
```
add n/James Ho ic/S1234567D x/M dob/01-04-2003 p/22224444 e/jamesho@example.com a/123, Clementi Rd, 1234665 al/Dust c/Allergic rhinitis
edit 1 c/test
delete 1 c/test
find James c/test
apt 1 d/10-02-2026 14:00 dur/30 c/test
dapt 1 c/test
lsapt c/test
```

But argument-less commands will ignore(as per our docs)
```
exit c/test
help c/test
list c/test
clear c/test
```